### PR TITLE
[UI] PC 화면에서 사이드 모달로 개선 (#2)

### DIFF
--- a/src/chatbot-widget.js
+++ b/src/chatbot-widget.js
@@ -116,10 +116,11 @@
 
                 .chatbot-modal {
                     position: fixed;
-                    top: 5%;
+                    top: 0;
+                    bottom: 0;
                     ${this.config.position === 'left' ? 'left' : 'right'}: 0;
                     width: 30%;
-                    height: 90%;
+                    height: 100%;
                     background: white;
                     border-radius: 0;
                     box-shadow: ${this.config.position === 'left' ? '10px' : '-10px'} 0 50px rgba(0, 0, 0, 0.3);


### PR DESCRIPTION
## 📝 구현 내용
PC 환경에서 챗봇 위젯이 화면 우측에 height 100%의 사이드 모달로 표시되도록 수정했습니다.

### 변경사항
- `.chatbot-modal`의 `top: 5%`, `height: 90%` → `top: 0`, `bottom: 0`, `height: 100%`로 변경
- PC에서 전체 높이를 차지하는 사이드 모달로 표시
- 모바일 환경은 기존 동작 유지 (미디어 쿼리 그대로)

## 💡 배운 점
### CSS height 100% 적용 시 주의사항
- `height: 100%`만으로는 때때로 부족할 수 있음
- `top: 0`과 `bottom: 0`을 함께 명시하면 더 확실하게 전체 높이를 보장
- `position: fixed` 요소에서 특히 중요

### 반응형 디자인 전략
- 현재는 CSS 미디어 쿼리로만 처리 (768px 기준)
- PC에서 브라우저 창 크기를 줄이면 모바일 스타일 적용됨
- 이는 의도된 동작이지만, 향후 개선 여지 있음

## 🔄 시행착오
1. 처음에는 `height: 100%`만 적용했으나 하단에 약간의 여백 발생
2. `bottom: 0`을 추가하여 완전한 전체 높이 확보

## ⚠️ 향후 주의사항
- 현재 CSS 미디어 쿼리만으로 디바이스 구분
- 더 정확한 디바이스 감지가 필요한 경우 JavaScript 로직 추가 고려 (이슈 #4)
- 태블릿 등 중간 크기 디바이스에 대한 별도 처리 필요할 수 있음

## ✅ 테스트
- [x] PC Chrome에서 사이드 모달 표시 확인
- [x] 모바일 반응형 동작 유지 확인
- [x] 하단 여백 제거 확인

Fixes #2