### PR TITLE
feat: iframe INITIAL_DATA postMessage 응답 로직 추가

### DIFF
--- a/src/chatbot-widget.js
+++ b/src/chatbot-widget.js
@@ -514,7 +514,7 @@
             const url = new URL(this.config.chatbotUrl);
             url.searchParams.set('clientId', this.config.clientId);
             url.searchParams.set('appId', this.config.appId);
-            
+
             // 隠しiframeを事前に作成してロード開始
             this.iframe = document.createElement('iframe');
             this.iframe.className = 'chatbot-iframe';
@@ -528,8 +528,50 @@
                 this.isIframePreloaded = true;
             };
 
+            // iframe의 READY 메시지를 수신하여 INITIAL_DATA 응답
+            this.setupPostMessageHandler();
+
             // bodyに隠した状態で追加して事前ロード
             document.body.appendChild(this.iframe);
+        }
+
+        // iframe과의 postMessage 통신 설정
+        setupPostMessageHandler() {
+            this.messageHandler = (event) => {
+                let message;
+                if (typeof event.data === 'string') {
+                    try {
+                        message = JSON.parse(event.data);
+                    } catch {
+                        return;
+                    }
+                } else {
+                    message = event.data;
+                }
+
+                // iframe에서 READY 메시지를 받으면 INITIAL_DATA 응답
+                if (message && message.type === 'READY') {
+                    this.sendInitialData();
+                }
+            };
+
+            window.addEventListener('message', this.messageHandler);
+        }
+
+        // iframe에 INITIAL_DATA 전송
+        sendInitialData() {
+            if (!this.iframe || !this.iframe.contentWindow) return;
+
+            const initialData = {
+                type: 'INITIAL_DATA',
+                payload: {
+                    clientId: this.config.clientId,
+                    appId: this.config.appId
+                }
+            };
+
+            this.iframe.contentWindow.postMessage(initialData, '*');
+            console.log('INITIAL_DATA sent to iframe:', initialData.payload);
         }
 
         bindLinkTriggers() {


### PR DESCRIPTION
## Summary
- 위젯에서 iframe의 `READY` postMessage를 수신하고 `INITIAL_DATA`를 응답하는 로직 추가
- 채팅 본체가 embedded 환경에서 `INITIAL_DATA`를 필수로 요구하면서 드로어 내부가 빈 화면으로 표시되던 버그 수정
- `clientId`, `appId`를 payload로 전달

## Test plan
- [x] 로컬에서 플로팅 버튼 클릭 시 채팅 인터페이스 정상 표시 확인
- [x] 콘솔에서 READY → INITIAL_DATA → ClientConfig updated 흐름 확인
- [ ] Amplify 배포 후 `develop.dwktomals1x32.amplifyapp.com`에서 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)